### PR TITLE
Pin pint to fix openff units problem

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - openff-forcefields
   - openff-toolkit==0.10.6
   - openff-units>=0.1.8
+  - pint==0.19.2
   - openmm
   - openmmtools
   - pip


### PR DESCRIPTION
With pint 0.20 you get `ModuleNotFoundError: No module named 'pint.measurement'`