### PR TITLE
Update MacOS runners so they exist

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15, macos-11]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9",]
 
     steps:


### PR DESCRIPTION
Runner for "`macos-10.15`" does not exist: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

Tests have been stalling on trying to get a resource, because no such resource exists. Let's settle for `latest` and call it good. We don't have that much OS-specific software in our stack (that isn't well-tested elsewhere), and none currently in the codebase we own, right?