### PR TITLE
Pin macos runner to v12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         python-version: ["3.11",]
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Note: we temporarily pin to macos-12 to avoid compatibility issues
+        # between AT22+ and macos-13+ runners
         os: [ubuntu-latest, macos-12]
         python-version: ["3.11",]
 


### PR DESCRIPTION
Temporary pin to macos-12:

macos-13 runners aren't compatible with AT22 or AT23, and macos-14/latest (osx-arm64) isn't compatible with AmberTools.