### PR TITLE
bumping openfe_showcase.ipynb from 1.0.1 to 1.1.0

### DIFF
--- a/showcase/openfe_showcase.ipynb
+++ b/showcase/openfe_showcase.ipynb
@@ -88,7 +88,7 @@
     "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
     "    !pip install -q condacolab\n",
     "    import condacolab\n",
-    "    condacolab.install_from_url(\"https://github.com/OpenFreeEnergy/openfe/releases/download/v1.0.1/OpenFEforge-1.0.1-Linux-x86_64.sh\")"
+    "    condacolab.install_from_url(\"https://github.com/OpenFreeEnergy/openfe/releases/download/v1.1.0/OpenFEforge-1.1.0-Linux-x86_64.sh\")"
    ]
   },
   {


### PR DESCRIPTION
bumping to version 1.1.0. This only affects the colab build. 