### PR TITLE
Fix cookbook rendering issues

### DIFF
--- a/cookbook/bespoke_parameters_showcase.ipynb
+++ b/cookbook/bespoke_parameters_showcase.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "# Recap\n",
     "\n",
-    "So to recap the workflow can be reduced to the following steps:\n",
+    "So to recap the workflow can be reduced to the following steps:\n\n",
     "- Plan the RBFE network\n",
     "- Create a single SMIRNOFF style force field with all of the bespoke parameters for the network using the BespokeFit `combine` CLI\n",
     "- Store the force field as a string in the OpenFE protocol under the `settings.forcefield_settings.small_molecule_forcefield` field\n",

--- a/cookbook/user_charges.ipynb
+++ b/cookbook/user_charges.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "Unfortunately charge assignment can be both, a) time consuming for large molecules, and b) non-deterministic, especially when the molecule occupies a conformation far from a local minima in the AM1 energetic landscape. The latter can be particularly problematic as this can lead to significant differences in assigned partial charges between Protocol simulation repeats.\n",
     "\n",
-    "To avoid these issues, we recommend applying `user charges` to `SmallMoleculeComponents`. In its simplest form, this is done by converting the `SmallMoleculeComponent` to an `OpenFF Molecule` calling the [OpenFF Molecule's `assign_partial_charges method`](https://docs.openforcefield.org/projects/toolkit/en/latest/api/generated/openff.toolkit.topology.Molecule.html#openff.toolkit.topology.Molecule.assign_partial_charges) and then re-loading it back into a `SmallMoleculeComponent` before further manipulation."
+    "To avoid these issues, we recommend applying `user charges` to `SmallMoleculeComponents`. In its simplest form, this is done by converting the `SmallMoleculeComponent` to an `OpenFF Molecule` calling the OpenFF Molecule's [assign_partial_charges method](https://docs.openforcefield.org/projects/toolkit/en/latest/api/generated/openff.toolkit.topology.Molecule.html#openff.toolkit.topology.Molecule.assign_partial_charges) and then re-loading it back into a `SmallMoleculeComponent` before further manipulation."
    ]
   },
   {


### PR DESCRIPTION
Fix up some rendering issues in the docs:
Bespokefit list not rendering 
<img width="915" alt="image" src="https://github.com/user-attachments/assets/a97ec2d8-4f96-42d1-b39f-006f9c74b875">

User charges link to openff 
<img width="906" alt="image" src="https://github.com/user-attachments/assets/4cb7f51a-450b-4a47-be83-59fdd21b5acf">
