### PR TITLE
adding colab installs to some notebooks

### DIFF
--- a/abfe_tutorial/python_tutorial.ipynb
+++ b/abfe_tutorial/python_tutorial.ipynb
@@ -23,6 +23,57 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f9154ba7",
+   "metadata": {},
+   "source": [
+    "# 0. Setup for Google Colab\n",
+    "\n",
+    "If you are running this example in Google Colab, run the following cells to setup the environment. If you are running this notebook locally, skip down to `1. Overview`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6173dd67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    !pip install -q condacolab\n",
+    "    import condacolab\n",
+    "    condacolab.install_from_url(\"https://github.com/OpenFreeEnergy/ExampleNotebooks/releases/download/april-2025/OpenFEforge-1.5.0.dev0-Linux-x86_64.sh\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e888557",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    import condacolab\n",
+    "    import locale\n",
+    "    locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "    !mkdir inputs && cd inputs && openfe fetch rbfe-tutorial\n",
+    "    for _ in range(3):\n",
+    "      # Sometimes we have to re-run the check\n",
+    "      try:\n",
+    "        condacolab.check()\n",
+    "      except:\n",
+    "        pass\n",
+    "      else:\n",
+    "        break"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "fc97de03",

--- a/ahfe_tutorial/python_tutorial.ipynb
+++ b/ahfe_tutorial/python_tutorial.ipynb
@@ -23,6 +23,57 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e26c8170",
+   "metadata": {},
+   "source": [
+    "# 0. Setup for Google Colab\n",
+    "\n",
+    "If you are running this example in Google Colab, run the following cells to setup the environment. If you are running this notebook locally, skip down to `1. Overview`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "525ac910",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    !pip install -q condacolab\n",
+    "    import condacolab\n",
+    "    condacolab.install_from_url(\"https://github.com/OpenFreeEnergy/ExampleNotebooks/releases/download/april-2025/OpenFEforge-1.5.0.dev0-Linux-x86_64.sh\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "808ba76a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    import condacolab\n",
+    "    import locale\n",
+    "    locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "    !mkdir inputs && cd inputs && openfe fetch rbfe-tutorial\n",
+    "    for _ in range(3):\n",
+    "      # Sometimes we have to re-run the check\n",
+    "      try:\n",
+    "        condacolab.check()\n",
+    "      except:\n",
+    "        pass\n",
+    "      else:\n",
+    "        break"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "fc97de03",

--- a/openmm_md/plain_md.ipynb
+++ b/openmm_md/plain_md.ipynb
@@ -66,6 +66,57 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fc27c86c",
+   "metadata": {},
+   "source": [
+    "# 0. Setup for Google Colab\n",
+    "\n",
+    "If you are running this example in Google Colab, run the following cells to setup the environment. If you are running this notebook locally, skip down to `1. Overview`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6559bc05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    !pip install -q condacolab\n",
+    "    import condacolab\n",
+    "    condacolab.install_from_url(\"https://github.com/OpenFreeEnergy/ExampleNotebooks/releases/download/april-2025/OpenFEforge-1.5.0.dev0-Linux-x86_64.sh\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb1368ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    import condacolab\n",
+    "    import locale\n",
+    "    locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "    !mkdir inputs && cd inputs && openfe fetch rbfe-tutorial\n",
+    "    for _ in range(3):\n",
+    "      # Sometimes we have to re-run the check\n",
+    "      try:\n",
+    "        condacolab.check()\n",
+    "      except:\n",
+    "        pass\n",
+    "      else:\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0eb8203a-650f-4703-b032-dbafb605061b",
    "metadata": {},
    "source": [

--- a/plotting_rbfes_with_cinnabar/PlottingFreeEnergiesUsingCinnabar.ipynb
+++ b/plotting_rbfes_with_cinnabar/PlottingFreeEnergiesUsingCinnabar.ipynb
@@ -11,6 +11,57 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6f3d03c2",
+   "metadata": {},
+   "source": [
+    "# 0. Setup for Google Colab\n",
+    "\n",
+    "If you are running this example in Google Colab, run the following cells to setup the environment. If you are running this notebook locally, skip down to `1. Overview`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04aa17bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    !pip install -q condacolab\n",
+    "    import condacolab\n",
+    "    condacolab.install_from_url(\"https://github.com/OpenFreeEnergy/ExampleNotebooks/releases/download/april-2025/OpenFEforge-1.5.0.dev0-Linux-x86_64.sh\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d297968",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "# Only run this cell if on google colab\n",
+    "import os\n",
+    "if \"COLAB_RELEASE_TAG\" in os.environ:\n",
+    "    import condacolab\n",
+    "    import locale\n",
+    "    locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "    !mkdir inputs && cd inputs && openfe fetch rbfe-tutorial\n",
+    "    for _ in range(3):\n",
+    "      # Sometimes we have to re-run the check\n",
+    "      try:\n",
+    "        condacolab.check()\n",
+    "      except:\n",
+    "        pass\n",
+    "      else:\n",
+    "        break"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "6abcaae7-f5fd-483c-972f-5bb5b6d4908a",


### PR DESCRIPTION
I added colab installs for the tutorials, but not the cookbooks. I figure that cookbooks are targeted more toward people that already have a working installation locally.