### PR TITLE
CI autocomment should use colab, not binder

### DIFF
--- a/.github/workflows/binder-badge.yaml
+++ b/.github/workflows/binder-badge.yaml
@@ -1,17 +1,17 @@
-#./.github/workflows/binder-badge.yaml
-name: Binder Badge
+#./.github/workflows/colab-badge.yaml
+name: Colab Badge
 on: 
   pull_request_target:
     types: [opened]
 
 jobs:
-  binder:
+  colab:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-    - name: comment on PR with Binder link
-      uses: actions/github-script@v3
+    - name: comment on PR with Colab link
+      uses: actions/github-script@v8
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
@@ -21,7 +21,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
+            body: `[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/OpenFreeEnergy/ExampleNotebooks/blob/${PR_HEAD_REF}/showcase)) :point_left: Launch a Colab session on branch ``${PR_HEAD_REF}``.
           })
       env:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->


## Checklist
* [ ] Added a ``news`` entry
<!-- see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command) -->

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
