### PR TITLE
fix septop diagram aspect ratio

### DIFF
--- a/openmm_septop/septop_tutorial.ipynb
+++ b/openmm_septop/septop_tutorial.ipynb
@@ -23,7 +23,7 @@
    "id": "23881797-0bd3-408b-9212-ac206d46cd39",
    "metadata": {},
    "source": [
-    "<img src=\"septop_cycle.png\" width=600 height=600 />"
+    "<img src=\"septop_cycle.png\" width=600/>"
    ]
   },
   {


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

it's currently squished: <img width="1140" height="1048" alt="image" src="https://github.com/user-attachments/assets/a0b7fbe8-e436-4cc3-8814-25d104d57a5c" />

## Checklist
* [ ] Added a ``news`` entry
<!-- see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command) -->

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.
