### PR TITLE
Partial charge assignation using NAGL in example notebook

### DIFF
--- a/rbfe_tutorial/rbfe_python_tutorial.ipynb
+++ b/rbfe_tutorial/rbfe_python_tutorial.ipynb
@@ -70,7 +70,7 @@
     "from openfe.protocols.openmm_utils.omm_settings import OpenFFPartialChargeSettings\n",
     "from openfe.protocols.openmm_utils.charge_generation import bulk_assign_partial_charges\n",
     "\n",
-    "charge_settings = OpenFFPartialChargeSettings(partial_charge_method=\"am1bcc\", off_toolkit_backend=\"ambertools\")\n",
+    "charge_settings = OpenFFPartialChargeSettings(partial_charge_method=\"nagl\")\n",
     "\n",
     "charged_ligands = bulk_assign_partial_charges(\n",
     "    molecules=ligands,\n",
@@ -573,7 +573,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I believe we want to make sure that we use OpenFF's NAGL when assigning partial charges in the python API tutorial. This change accomplishes that.