### PR TITLE
CI should use latest openfe release

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -13,5 +13,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - python
-  - openfe
+  - openfe==1.9.0
   - openff-interchange-base != 0.5.1  # https://github.com/openforcefield/openff-interchange/issues/1450

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,6 +13,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - python
-  - gufe >=1.7.0, <1.8.0
-  - openfe==1.8.0
+  - openfe
   - openff-interchange-base != 0.5.1  # https://github.com/openforcefield/openff-interchange/issues/1450

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,5 +13,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - python
-  - openfe==1.9.0
+  - openfe
   - openff-interchange-base != 0.5.1  # https://github.com/openforcefield/openff-interchange/issues/1450


### PR DESCRIPTION
our example notebooks should always work with the latest version of openfe, so keeping a pin here seems unnecessary. 