### PR TITLE
bump openfe pin to 1.9.1

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -13,6 +13,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - python
-  - gufe >=1.7.0, <1.8.0
-  - openfe==1.8.0
+  - openfe == 1.9.1
   - openff-interchange-base != 0.5.1  # https://github.com/openforcefield/openff-interchange/issues/1450


### PR DESCRIPTION
I think we should keep this pinned, so that users can check out old versions of examplenotebooks and build the appropriate environment.

Ideally, we would have a gh action that makes a PR to auto-bump this pin when we cut a release. Testing notebooks prior to an openfe release happens on the openfe side: https://github.com/OpenFreeEnergy/openfe/actions/workflows/test-example-notebooks.yaml